### PR TITLE
Introduce CommandArgument and CommandArguments for slash commands

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pixelservices.mobot</groupId>
         <artifactId>mobot</artifactId>
-        <version>0.4.5</version>
+        <version>0.4.6</version>
     </parent>
 
     <artifactId>mobot-api</artifactId>

--- a/api/src/main/java/com/pixelservices/mobot/api/commands/CommandArgument.java
+++ b/api/src/main/java/com/pixelservices/mobot/api/commands/CommandArgument.java
@@ -1,0 +1,41 @@
+package com.pixelservices.mobot.api.commands;
+
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+
+public class CommandArgument {
+    private final OptionMapping option;
+
+    public CommandArgument(OptionMapping option) {
+        this.option = option;
+    }
+
+    public boolean isPresent() {
+        return option != null;
+    }
+
+    public String getAsString() {
+        return option != null ? option.getAsString() : null;
+    }
+
+    public Integer getAsInt() {
+        return option != null ? option.getAsInt() : null;
+    }
+
+    public Boolean getAsBoolean() {
+        return option != null ? option.getAsBoolean() : null;
+    }
+
+    public Double getAsDouble() {
+        return option != null ? option.getAsDouble() : null;
+    }
+
+    public Message.Attachment getAsAttachment() {
+        return option != null ? option.getAsAttachment() : null;
+    }
+
+    public OptionMapping getRaw() {
+        return option;
+    }
+}
+

--- a/api/src/main/java/com/pixelservices/mobot/api/commands/CommandArguments.java
+++ b/api/src/main/java/com/pixelservices/mobot/api/commands/CommandArguments.java
@@ -1,0 +1,47 @@
+package com.pixelservices.mobot.api.commands;
+
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CommandArguments {
+    private final Map<String, CommandArgument> args = new HashMap<>();
+
+    public void put(String name, OptionMapping mapping) {
+        args.put(name, new CommandArgument(mapping));
+    }
+
+    public CommandArgument get(String name) {
+        return args.getOrDefault(name, new CommandArgument(null));
+    }
+
+    public String getAsString(String name) {
+        return get(name).getAsString();
+    }
+
+    public Integer getAsInt(String name) {
+        return get(name).getAsInt();
+    }
+
+    public Double getAsDouble(String name) {
+        return get(name).getAsDouble();
+    }
+
+    public Boolean getAsBoolean(String name) {
+        return get(name).getAsBoolean();
+    }
+
+    public net.dv8tion.jda.api.entities.Message.Attachment getAsAttachment(String name) {
+        return get(name).getAsAttachment();
+    }
+
+    public boolean has(String name) {
+        return args.containsKey(name) && args.get(name).isPresent();
+    }
+
+    public Map<String, CommandArgument> asMap() {
+        return Map.copyOf(args);
+    }
+}
+

--- a/api/src/main/java/com/pixelservices/mobot/api/commands/SlashCommandArgument.java
+++ b/api/src/main/java/com/pixelservices/mobot/api/commands/SlashCommandArgument.java
@@ -3,11 +3,7 @@ package com.pixelservices.mobot.api.commands;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import org.jetbrains.annotations.NotNull;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Annotation to define an argument for a SlashCommand.

--- a/api/src/main/java/com/pixelservices/mobot/api/modules/MbModule.java
+++ b/api/src/main/java/com/pixelservices/mobot/api/modules/MbModule.java
@@ -7,7 +7,6 @@ import com.pixelservices.mobot.api.env.FinalizedBotEnvironment;
 import com.pixelservices.mobot.api.env.PrimitiveBotEnvironment;
 import com.pixelservices.mobot.api.modules.listener.ListenerBridge;
 import com.pixelservices.mobot.api.modules.listener.ModuleListener;
-import com.pixelservices.mobot.api.scheduler.ScheduledTask;
 import com.pixelservices.mobot.api.scheduler.TaskScheduler;
 import com.pixelservices.plugin.Plugin;
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pixelservices.mobot</groupId>
         <artifactId>mobot</artifactId>
-        <version>0.4.5</version>
+        <version>0.4.6</version>
     </parent>
 
     <artifactId>mobot-core</artifactId>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.pixelservices.mobot</groupId>
             <artifactId>mobot-api</artifactId>
-            <version>0.4.5</version>
+            <version>0.4.6</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/core/src/main/java/com/pixelservices/mobot/MoBot.java
+++ b/core/src/main/java/com/pixelservices/mobot/MoBot.java
@@ -1,15 +1,14 @@
 package com.pixelservices.mobot;
 
-import com.pixelservices.mobot.api.env.FinalizedBotEnvironment;
-import com.pixelservices.mobot.api.env.PrimitiveBotEnvironment;
-import com.pixelservices.mobot.api.scheduler.TaskScheduler;
-import com.pixelservices.mobot.commands.CommandManager;
 import com.pixelservices.config.ConfigFactory;
 import com.pixelservices.config.YamlConfig;
-import com.pixelservices.mobot.console.Console;
-import com.pixelservices.mobot.exceptions.BotStartupException;
 import com.pixelservices.logger.Logger;
 import com.pixelservices.logger.LoggerFactory;
+import com.pixelservices.mobot.api.env.FinalizedBotEnvironment;
+import com.pixelservices.mobot.api.env.PrimitiveBotEnvironment;
+import com.pixelservices.mobot.commands.CommandManager;
+import com.pixelservices.mobot.console.Console;
+import com.pixelservices.mobot.exceptions.BotStartupException;
 import com.pixelservices.mobot.modules.ModuleManager;
 import com.pixelservices.mobot.scheduler.BotTaskScheduler;
 import com.pixelservices.mobot.utils.UpdateChecker;

--- a/core/src/main/java/com/pixelservices/mobot/commands/CommandManager.java
+++ b/core/src/main/java/com/pixelservices/mobot/commands/CommandManager.java
@@ -1,12 +1,12 @@
 package com.pixelservices.mobot.commands;
 
+import com.pixelservices.logger.Logger;
+import com.pixelservices.logger.LoggerFactory;
 import com.pixelservices.mobot.api.commands.SlashCommand;
 import com.pixelservices.mobot.api.commands.SlashCommandArgument;
 import com.pixelservices.mobot.api.commands.SlashCommandChoice;
 import com.pixelservices.mobot.api.commands.SlashCommandHandler;
 import com.pixelservices.mobot.exceptions.CommandExecuteException;
-import com.pixelservices.logger.Logger;
-import com.pixelservices.logger.LoggerFactory;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;

--- a/core/src/main/java/com/pixelservices/mobot/console/Console.java
+++ b/core/src/main/java/com/pixelservices/mobot/console/Console.java
@@ -1,11 +1,11 @@
 package com.pixelservices.mobot.console;
 
+import com.pixelservices.logger.Logger;
+import com.pixelservices.logger.LoggerFactory;
 import com.pixelservices.mobot.MoBot;
 import com.pixelservices.mobot.console.impl.ModuleCommand;
 import com.pixelservices.mobot.console.impl.SetTokenCommand;
 import com.pixelservices.mobot.console.impl.VersionCommand;
-import com.pixelservices.logger.Logger;
-import com.pixelservices.logger.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/core/src/main/java/com/pixelservices/mobot/console/impl/ModuleCommand.java
+++ b/core/src/main/java/com/pixelservices/mobot/console/impl/ModuleCommand.java
@@ -1,17 +1,16 @@
 package com.pixelservices.mobot.console.impl;
 
+import com.pixelservices.logger.Logger;
 import com.pixelservices.mobot.api.modules.MbModule;
 import com.pixelservices.mobot.api.modules.ModuleState;
 import com.pixelservices.mobot.api.scheduler.ScheduledTask;
 import com.pixelservices.mobot.api.scheduler.TaskScheduler;
 import com.pixelservices.mobot.console.ConsoleCommand;
-import com.pixelservices.logger.Logger;
 import com.pixelservices.mobot.modules.ModuleManager;
 import com.pixelservices.plugin.PluginWrapper;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.Set;
 
 public class ModuleCommand implements ConsoleCommand {
 

--- a/core/src/main/java/com/pixelservices/mobot/console/impl/SetTokenCommand.java
+++ b/core/src/main/java/com/pixelservices/mobot/console/impl/SetTokenCommand.java
@@ -1,9 +1,9 @@
 package com.pixelservices.mobot.console.impl;
 
 import com.pixelservices.config.ConfigFactory;
-import com.pixelservices.mobot.console.ConsoleCommand;
 import com.pixelservices.config.YamlConfig;
 import com.pixelservices.logger.Logger;
+import com.pixelservices.mobot.console.ConsoleCommand;
 
 public class SetTokenCommand implements ConsoleCommand {
 

--- a/core/src/main/java/com/pixelservices/mobot/console/impl/VersionCommand.java
+++ b/core/src/main/java/com/pixelservices/mobot/console/impl/VersionCommand.java
@@ -1,7 +1,7 @@
 package com.pixelservices.mobot.console.impl;
 
-import com.pixelservices.mobot.console.ConsoleCommand;
 import com.pixelservices.logger.Logger;
+import com.pixelservices.mobot.console.ConsoleCommand;
 import com.pixelservices.mobot.utils.UpdateChecker;
 
 public class VersionCommand implements ConsoleCommand {

--- a/core/src/main/java/com/pixelservices/mobot/logger/CustomLogbackAppender.java
+++ b/core/src/main/java/com/pixelservices/mobot/logger/CustomLogbackAppender.java
@@ -1,10 +1,10 @@
 package com.pixelservices.mobot.logger;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.ThrowableProxy;
 import ch.qos.logback.core.AppenderBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ch.qos.logback.classic.spi.ThrowableProxy;
 
 public class CustomLogbackAppender extends AppenderBase<ILoggingEvent> {
     private final Logger customLogger = LoggerFactory.getLogger("Internal");

--- a/core/src/main/java/com/pixelservices/mobot/modules/RegistryBridgeImpl.java
+++ b/core/src/main/java/com/pixelservices/mobot/modules/RegistryBridgeImpl.java
@@ -1,8 +1,8 @@
 package com.pixelservices.mobot.modules;
 
+import com.pixelservices.mobot.api.commands.SlashCommandHandler;
 import com.pixelservices.mobot.api.modules.RegistryBridge;
 import com.pixelservices.mobot.commands.CommandManager;
-import com.pixelservices.mobot.api.commands.SlashCommandHandler;
 
 /**
  * This class serves as a bridge for registering commands and command handlers.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.pixelservices.mobot</groupId>
     <artifactId>mobot</artifactId>
-    <version>0.4.5</version>
+    <version>0.4.6</version>
     <packaging>pom</packaging>
 
     <distributionManagement>


### PR DESCRIPTION
This PR adds two new classes to improve slash command argument handling:
- ``CommandArgument`` – represents a single argument with type-safe access methods (e.g., .getAsString()).
- ``CommandArguments`` – a container for all arguments passed to a command, replacing the old Map<String, Object> approach.

### Changes:
- Slash command methods now support only two valid signatures:
   - ``(SlashCommandInteractionEvent event)``
   - ``(SlashCommandInteractionEvent event, CommandArguments args)``
- Methods using the old ``(event, Map)`` signature are marked as deprecated at compile-time.
- Unsupported method signatures now produce compile-time errors.
- Existing modules using the old ``(event, Map)`` signature continue to work but receive deprecation warnings.